### PR TITLE
Remove basepath

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,7 +1,5 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  basePath:
-    process.env.NODE_ENV === "development" ? "" : "/climate-policy-hub-site",
   reactStrictMode: true,
   output: "export",
 }


### PR DESCRIPTION
Despite Github pages URL having repo name, the actual deployment will go to https://climatepolicyhub.netzeropathfinders.com without basepath